### PR TITLE
Bind address command-line option for Arachni's XML-RPC server

### DIFF
--- a/bin/arachni_xmlrpcd
+++ b/bin/arachni_xmlrpcd
@@ -57,6 +57,9 @@ begin
             when '--port'
                 options.rpc_port = arg.to_i
 
+            when '--bind'
+                options.rpc_bind = arg.to_s
+
             when '--pool-size'
                 options.pool_size = arg.to_i
 

--- a/lib/options.rb
+++ b/lib/options.rb
@@ -329,6 +329,7 @@ class Options
     attr_accessor :spider_first
 
     attr_accessor :rpc_port
+    attr_accessor :rpc_bind
     attr_accessor :ssl
     attr_accessor :ssl_pkey
     attr_accessor :ssl_cert

--- a/lib/rpc/xml/server/base.rb
+++ b/lib/rpc/xml/server/base.rb
@@ -59,6 +59,7 @@ class Base
         end
 
         @server = WebServ.new(
+            :BindAddress     => opts.rpc_bind,
             :Port            => opts.rpc_port,
             :SSLEnable       => true,
             :SSLVerifyClient => verification,

--- a/lib/rpc/xml/server/dispatcher.rb
+++ b/lib/rpc/xml/server/dispatcher.rb
@@ -56,6 +56,7 @@ class Dispatcher < Base
 
         @opts = opts
         @opts.rpc_port  ||= 7331
+        @opts.rpc_bind  ||= '0.0.0.0'
         @opts.pool_size ||= 5
 
         if opts.help
@@ -211,6 +212,9 @@ class Dispatcher < Base
 
     --port                      specify port to listen to
                                     (Default: #{@opts.rpc_port})
+
+    --bind                      specify bind address
+                                    (Default: #{@opts.rpc_bind})
 
     --reroute-to-logfile        reroute all output to a logfile under 'logs/'
 


### PR DESCRIPTION
I have added a command-line option to specify Arachni's XML-RPC server's bind address. This was added specifically to be able to bind to 127.0.0.1 and thereby only listening on the local loopback interface. This might be useful to others as well.

The changes are simple and have been tested on my Ubuntu 8.04 machine, albeit only by hacking on the source in the CDE package (i.e. it was not tested from the source repository).

P.S. This is my first pull request on github, so please excuse any missing information or other problems.
