### PR TITLE
Changed bounding regex symbols for modules/recon/grep/ssn.rb so that SSN...

### DIFF
--- a/modules/recon/grep/ssn.rb
+++ b/modules/recon/grep/ssn.rb
@@ -25,7 +25,7 @@ class SSN < Arachni::Module::Base
     end
 
     def run( )
-        regexp = /^(?!000)([0-6]\d{2}|7([0-6]\d|7[012]))([ -]?)(?!00)\d\d\3(?!0000)\d{4}$/
+        regexp = /\b(?!000)([0-6]\d{2}|7([0-6]\d|7[012]))([ -]?)(?!00)\d\d\3(?!0000)\d{4}\b/
         match_and_log( regexp )
     end
 


### PR DESCRIPTION
...s can be caught anywhere in the text--not just when they make up an entire line
