### PR TITLE
jQuery Easy Confirm Dialog integration

### DIFF
--- a/lib/arachni/ui/web/server/public/js/jquery.easy-confirm-dialog.js
+++ b/lib/arachni/ui/web/server/public/js/jquery.easy-confirm-dialog.js
@@ -1,0 +1,155 @@
+/**
+ * jQuery Easy Confirm Dialog plugin 1.2
+ *
+ * Copyright (c) 2010 Emil Janitzek (http://projectshadowlight.org)
+ * Based on Confirm 1.3 by Nadia Alramli (http://nadiana.com/)
+ *
+ * Samples and instructions at: 
+ * http://projectshadowlight.org/jquery-easy-confirm-dialog/
+ *
+ * This script is free software: you can redistribute it and/or modify it 
+ * under the terms of the GNU General Public License as published by the Free 
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ */
+(function($) {
+    $.easyconfirm = {};
+    $.easyconfirm.locales = {};
+    $.easyconfirm.locales.enUS = {
+        title: 'Are you sure?',
+        text: 'Are you sure that you want to perform this action?',
+        button: ['Cancel', 'Confirm'],
+        closeText: 'close'
+    };
+    $.easyconfirm.locales.svSE = {
+        title: 'Är du säker?',
+        text: 'Är du säker på att du vill genomföra denna åtgärden?',
+        button: ['Avbryt', 'Bekräfta'],
+        closeText: 'stäng'
+    };
+
+    $.fn.easyconfirm = function(options) {
+
+        var _attr = $.fn.attr;
+
+        $.fn.attr = function(attr, value) {
+            // Let the original attr() do its work.
+            var returned = _attr.apply(this, arguments);
+
+            // Fix for jQuery 1.6+
+            if (attr == 'title' && returned === undefined) 
+                returned = '';
+
+            return returned;
+        };
+
+        var options = jQuery.extend({
+            eventType: 'click',
+            icon: 'help'
+        }, options);
+
+        var locale = jQuery.extend({}, $.easyconfirm.locales.enUS, options.locale);
+
+        // Shortcut to eventType.
+        var type = options.eventType;
+
+        return this.each(function() {
+            var target = this;
+            var $target = jQuery(target);
+
+            // If no events present then and if there is a valid url, then trigger url change
+            var urlClick = function() {
+                    if (target.href) {
+                        var length = String(target.href).length;
+                        if (target.href.substring(length - 1, length) != '#') 
+                            document.location = target.href;
+                    }
+                };
+
+            // If any handlers where bind before triggering, lets save them and add them later
+            var saveHandlers = function() {
+                    var events = jQuery.data(target, 'events');
+                    if (events) {
+                        target._handlers = new Array();
+                        for (var i in events[type]) {
+                            target._handlers.push(events[type][i]);
+                        }
+
+                        $target.unbind(type);
+                    }
+                };
+            // Re-bind old events
+            var rebindHandlers = function() {
+                    if (target._handlers !== undefined) {
+                        jQuery.each(target._handlers, function() {
+                            $target.bind(type, this);
+                        });
+                    }
+                };
+
+            if ($target.attr('title') !== null && $target.attr('title').length > 0) 
+                locale.text = $target.attr('title');
+
+            var dialog = (options.dialog === undefined || typeof(options.dialog) != 'object') ? 
+                $('<div class="dialog confirm">' + locale.text + '</div>') : 
+                options.dialog;
+
+            var buttons = {};
+            buttons[locale.button[1]] = function() {
+                // Unbind overriding handler and let default actions pass through
+                $target.unbind(type, handler);
+
+                // Close dialog
+                $(dialog).dialog("close");
+
+                // Check if there is any events on the target
+                if (jQuery.data(target, 'events')) {
+                    // Trigger click event.
+                    $target.click();
+                }
+                else {
+                    // No event trigger new url
+                    urlClick();
+                }
+
+                init();
+
+            };
+            buttons[locale.button[0]] = function() {
+                $(dialog).dialog("close");
+            };
+
+            $(dialog).dialog({
+                autoOpen: false,
+                resizable: false,
+                draggable: true,
+                closeOnEscape: true,
+                width: 'auto',
+                minHeight: 120,
+                maxHeight: 200,
+                buttons: buttons,
+                title: locale.title,
+                closeText: locale.closeText,
+                modal: true
+            });
+
+            // Handler that will override all other actions
+            var handler = function(event) {
+                    $(dialog).dialog('open');
+                    event.stopImmediatePropagation();
+                    event.preventDefault();
+                    return false;
+                };
+
+            var init = function() {
+                    saveHandlers();
+                    $target.bind(type, handler);
+                    rebindHandlers();
+                };
+
+            init();
+
+        });
+
+    };
+})(jQuery);

--- a/lib/arachni/ui/web/server/views/dispatchers.erb
+++ b/lib/arachni/ui/web/server/views/dispatchers.erb
@@ -46,7 +46,7 @@
         <% i += 1 %>
 
         <%if !dispatcher_stats['running_jobs'].empty? %>
-        <form style='display: inline' onsubmit="return confirm( 'Are you sure that you want to kill all running instances?' )" action="/dispatchers/<%=remove_proto( d_url.dup )%>/shutdown_all" method="post">
+        <form style='display: inline' class="confirm" action="/dispatchers/<%=remove_proto( d_url.dup )%>/shutdown_all" method="post">
             <%= csrf_tag %>
             <input type="submit" value="Shutdown all" />
         </form>
@@ -108,7 +108,7 @@
                             </form>
                             <% end %>
 
-                            <form style="display: inline" action="/dispatchers/<%=job['url']%>/shutdown" method="post">
+                            <form style="display: inline" class="confirm" action="/dispatchers/<%=job['url']%>/shutdown" method="post">
                                 <%= csrf_tag %>
                                 <input type="submit" value="Shutdown" />
                             </form>

--- a/lib/arachni/ui/web/server/views/dispatchers_edit.erb
+++ b/lib/arachni/ui/web/server/views/dispatchers_edit.erb
@@ -50,7 +50,7 @@
                 <td><%=dispatcher['url']%></td>
                 <td><%=dispatcher['alive'].to_s.capitalize%></td>
                 <td>
-                    <form action="/dispatchers/<%=dispatcher['id']%>/delete" method="post">
+                    <form class="confirm" action="/dispatchers/<%=dispatcher['id']%>/delete" method="post">
                         <%= csrf_tag %>
                         <input type="submit" value="Delete" />
                     </form>

--- a/lib/arachni/ui/web/server/views/instance.erb
+++ b/lib/arachni/ui/web/server/views/instance.erb
@@ -24,7 +24,7 @@
                 </form>
                 <%end%>
 
-                <form action="/instance/<%=remove_proto( params['url'] )%>/shutdown" method="post">
+                <form class="confirm" action="/instance/<%=remove_proto( params['url'] )%>/shutdown" method="post">
                     <%= csrf_tag %>
                     <input type="submit" value="Shutdown" />
                 </form>

--- a/lib/arachni/ui/web/server/views/layout.erb
+++ b/lib/arachni/ui/web/server/views/layout.erb
@@ -10,6 +10,7 @@
     <script type="text/javascript" src="/js/jquery-1.4.4.min.js"></script>
     <script type="text/javascript" src="/js/jquery-ui-1.8.9.custom.min.js"></script>
     <script type="text/javascript" src="/js/jquery-ui-timepicker.js"></script>
+    <script type="text/javascript" src="/js/jquery.easy-confirm-dialog.js"></script>
 
     <script type="text/javascript">
         function checkAll( type ) {
@@ -19,6 +20,13 @@
         function uncheckAll( type ) {
             $( "." + type ).attr( "checked", false )
         }
+
+        $(document).ready(function() {
+            $('.confirm').easyconfirm();
+            $('.confirm').click(function() {
+                $('.confirm').submit();
+            });
+        });
     </script>
 
     </head>

--- a/lib/arachni/ui/web/server/views/reports.erb
+++ b/lib/arachni/ui/web/server/views/reports.erb
@@ -10,7 +10,7 @@
                     <input type="submit" value="View formats" />
                 </form>
 
-                <form action="/reports/delete" method="post">
+                <form class="confirm" action="/reports/delete" method="post">
                     <%= csrf_tag %>
                     <input type="submit" value="Delete all" />
                 </form>
@@ -46,7 +46,7 @@
                 </td>
 
                 <td>
-                    <form action="/report/<%=report.id%>/delete" method="post">
+                    <form class="confirm" action="/report/<%=report.id%>/delete" method="post">
                         <%= csrf_tag %>
                         <input type="submit" value="Delete" />
                     </form>


### PR DESCRIPTION
I thought it may be nice given the existing structure of Arachni to add this dependency and give a simple way to protect users against accidentally deleting a report or shutting down a scan. Provides a nice looking UI element to work with, minimal code changes, and the text/interface to the dialog is customizable (if desired).

Helps me anyways from working to quickly ;) Cheers.
