### PR TITLE
Output the old non-HPG sitemap when not in high performance mode

### DIFF
--- a/lib/arachni/rpc/server/framework.rb
+++ b/lib/arachni/rpc/server/framework.rb
@@ -621,7 +621,7 @@ class Framework < ::Arachni::Framework
     # @see Arachni::Framework#auditstore_sitemap
     #
     def auditstore_sitemap
-        @override_sitemap.to_a
+        high_performance? ? @override_sitemap.to_a : super
     end
 
     def extended_running?


### PR DESCRIPTION
Noticed that the sitemap was empty when running the scanner in non-HPG mode.
