### PR TITLE
Fix spider.rb missing require

### DIFF
--- a/lib/arachni/spider.rb
+++ b/lib/arachni/spider.rb
@@ -14,6 +14,7 @@
     limitations under the License.
 =end
 
+require Arachni::Options.instance.dir['lib'] + 'ui/cli/output'
 require Arachni::Options.instance.dir['lib'] + 'module/utilities'
 require 'nokogiri'
 require Arachni::Options.instance.dir['lib'] + 'nokogiri/xml/node'


### PR DESCRIPTION
This allows you to "require 'arachni'" from an irb console or other script and it won't error out missing the ui/output module.
