### PR TITLE
Fix 279: Repack string before gsub

### DIFF
--- a/lib/arachni/element/form.rb
+++ b/lib/arachni/element/form.rb
@@ -1197,7 +1197,7 @@ class Form < Arachni::Element::Base
     # @return   [String]    the encoded string
     #
     def self.encode( str )
-        ::URI.encode( ::URI.encode( str, '+%' ).gsub( ' ', '+' ), ";&\\=\0" )
+        ::URI.encode( ::URI.encode( str, '+%' ).unpack("C*").pack("U*").gsub( ' ', '+' ), ";&\\=\0" )
     end
     # @see .encode
     def encode( str )


### PR DESCRIPTION
This pull requests fixes and invalid encoding issue in form.rb which caused arachni to crash. Simply repacks the string before performing the substitutions.
