### PR TITLE
Background image breaking on Safari (6.0 tested) with background-color set

### DIFF
--- a/lib/arachni/ui/web/server/public/style.css
+++ b/lib/arachni/ui/web/server/public/style.css
@@ -8,7 +8,7 @@ body {
 }
 
 .wrapper {
-    background: #ddd url('bodybg.png') repeat-x scroll top left;
+    background: url('bodybg.png') repeat-x scroll top left;
 }
 
 .subpage {


### PR DESCRIPTION
Removing the (seemingly superfluous) background-color portion of the wrapper class which is breaking the background-image on Safari (6.0 tested).
