### PR TITLE
Fix owasp hrefs

### DIFF
--- a/components/checks/active/csrf.rb
+++ b/components/checks/active/csrf.rb
@@ -34,7 +34,7 @@
 # @author Tasos "Zapotek" Laskos <tasos.laskos@arachni-scanner.com>
 #
 # @see http://en.wikipedia.org/wiki/Cross-site_request_forgery
-# @see http://www.owasp.org/index.php/Cross-Site_Request_Forgery_(CSRF)
+# @see https://www.owasp.org/index.php/Cross-Site_Request_Forgery_(CSRF)
 # @see http://www.cgisecurity.com/csrf-faq.html
 # @see http://cwe.mitre.org/data/definitions/352.html
 class Arachni::Checks::CSRF < Arachni::Check::Base
@@ -195,7 +195,7 @@ content on a forum, etc._
 },
                 references:  {
                     'Wikipedia'    => 'http://en.wikipedia.org/wiki/Cross-site_request_forgery',
-                    'OWASP'        => 'http://www.owasp.org/index.php/Cross-Site_Request_Forgery_(CSRF)',
+                    'OWASP'        => 'https://www.owasp.org/index.php/Cross-Site_Request_Forgery_(CSRF)',
                     'CGI Security' => 'http://www.cgisecurity.com/csrf-faq.html'
                 },
                 tags:            %w(csrf rdiff form token),

--- a/components/checks/active/ldap_injection.rb
+++ b/components/checks/active/ldap_injection.rb
@@ -13,7 +13,7 @@
 #
 # @see http://cwe.mitre.org/data/definitions/90.html
 # @see http://projects.webappsec.org/w/page/13246947/LDAP-Injection
-# @see http://www.owasp.org/index.php/LDAP_injection
+# @see https://www.owasp.org/index.php/LDAP_injection
 class Arachni::Checks::LdapInjection < Arachni::Check::Base
 
     def self.error_strings
@@ -62,7 +62,7 @@ known error messages.
                 tags:            %w(ldap injection regexp),
                 references:  {
                     'WASC'  => 'http://projects.webappsec.org/w/page/13246947/LDAP-Injection',
-                    'OWASP' => 'http://www.owasp.org/index.php/LDAP_injection'
+                    'OWASP' => 'https://www.owasp.org/index.php/LDAP_injection'
                 },
                 cwe:             90,
                 severity:        Severity::HIGH,

--- a/components/checks/active/os_cmd_injection.rb
+++ b/components/checks/active/os_cmd_injection.rb
@@ -12,7 +12,7 @@
 # @version 0.2.4
 #
 # @see http://cwe.mitre.org/data/definitions/78.html
-# @see http://www.owasp.org/index.php/OS_Command_Injection
+# @see https://www.owasp.org/index.php/OS_Command_Injection
 class Arachni::Checks::OsCmdInjection < Arachni::Check::Base
 
     def self.options
@@ -95,7 +95,7 @@ from that command contained within the server response. This indicates that prop
 input sanitisation is not occurring.
 },
                 references:  {
-                    'OWASP' => 'http://www.owasp.org/index.php/OS_Command_Injection',
+                    'OWASP' => 'https://www.owasp.org/index.php/OS_Command_Injection',
                     'WASC'  => 'http://projects.webappsec.org/w/page/13246950/OS%20Commanding'
                 },
                 tags:            %w(os command code injection regexp error),

--- a/components/checks/active/os_cmd_injection_timing.rb
+++ b/components/checks/active/os_cmd_injection_timing.rb
@@ -12,7 +12,7 @@
 # @version 0.3.2
 #
 # @see http://cwe.mitre.org/data/definitions/78.html
-# @see http://www.owasp.org/index.php/OS_Command_Injection
+# @see https://www.owasp.org/index.php/OS_Command_Injection
 class Arachni::Checks::OsCmdInjectionTiming < Arachni::Check::Base
 
     prefer :os_cmd_injection
@@ -73,7 +73,7 @@ was able to detect time based OS command injection. This indicates that proper
 input sanitisation is not occurring.
 },
                 references:  {
-                    'OWASP' => 'http://www.owasp.org/index.php/OS_Command_Injection'
+                    'OWASP' => 'https://www.owasp.org/index.php/OS_Command_Injection'
                 },
                 tags:            %w(os command code injection timing blind),
                 cwe:             78,

--- a/components/checks/active/path_traversal.rb
+++ b/components/checks/active/path_traversal.rb
@@ -12,7 +12,7 @@
 # @version 0.4.4
 #
 # @see http://cwe.mitre.org/data/definitions/22.html
-# @see http://www.owasp.org/index.php/Path_Traversal
+# @see https://www.owasp.org/index.php/Path_Traversal
 # @see http://projects.webappsec.org/Path-Traversal
 class Arachni::Checks::PathTraversal < Arachni::Check::Base
 
@@ -143,7 +143,7 @@ relative path to a common operating system file and have the contents of the fil
 included in the response.
 },
                 references:  {
-                    'OWASP' => 'http://www.owasp.org/index.php/Path_Traversal',
+                    'OWASP' => 'https://www.owasp.org/index.php/Path_Traversal',
                     'WASC'  => 'http://projects.webappsec.org/Path-Traversal'
                 },
                 tags:            %w(path traversal injection regexp),

--- a/components/checks/active/response_splitting.rb
+++ b/components/checks/active/response_splitting.rb
@@ -12,7 +12,7 @@
 # @version 0.2.1
 #
 # @see http://cwe.mitre.org/data/definitions/20.html
-# @see http://www.owasp.org/index.php/HTTP_Response_Splitting
+# @see https://www.owasp.org/index.php/HTTP_Response_Splitting
 # @see http://www.securiteam.com/securityreviews/5WP0E2KFGK.html
 class Arachni::Checks::ResponseSplitting < Arachni::Check::Base
 
@@ -64,7 +64,7 @@ other attacks.
 },
                 references:  {
                     'SecuriTeam' => 'http://www.securiteam.com/securityreviews/5WP0E2KFGK.html',
-                    'OWASP'      => 'http://www.owasp.org/index.php/HTTP_Response_Splitting'
+                    'OWASP'      => 'https://www.owasp.org/index.php/HTTP_Response_Splitting'
                 },
                 tags:            %w(response splitting injection header),
                 cwe:             20,

--- a/components/checks/active/sql_injection.rb
+++ b/components/checks/active/sql_injection.rb
@@ -15,7 +15,7 @@
 # @see http://unixwiz.net/techtips/sql-injection.html
 # @see http://en.wikipedia.org/wiki/SQL_injection
 # @see http://www.securiteam.com/securityreviews/5DP0N1P76E.html
-# @see http://www.owasp.org/index.php/SQL_Injection
+# @see https://www.owasp.org/index.php/SQL_Injection
 class Arachni::Checks::SqlInjection < Arachni::Check::Base
 
     def self.error_patterns
@@ -94,7 +94,7 @@ the request with a database related error.
                     'UnixWiz'    => 'http://unixwiz.net/techtips/sql-injection.html',
                     'Wikipedia'  => 'http://en.wikipedia.org/wiki/SQL_injection',
                     'SecuriTeam' => 'http://www.securiteam.com/securityreviews/5DP0N1P76E.html',
-                    'OWASP'      => 'http://www.owasp.org/index.php/SQL_Injection',
+                    'OWASP'      => 'https://www.owasp.org/index.php/SQL_Injection',
                     'WASC'       => 'http://projects.webappsec.org/w/page/13246963/SQL%20Injection',
                     'W3 Schools' => 'http://www.w3schools.com/sql/sql_injection.asp'
                 },

--- a/components/checks/active/sql_injection_differential.rb
+++ b/components/checks/active/sql_injection_differential.rb
@@ -18,7 +18,7 @@
 #
 # @see http://cwe.mitre.org/data/definitions/89.html
 # @see http://capec.mitre.org/data/definitions/7.html
-# @see http://www.owasp.org/index.php/Blind_SQL_Injection
+# @see https://www.owasp.org/index.php/Blind_SQL_Injection
 class Arachni::Checks::SqlInjectionDifferential < Arachni::Check::Base
 
     prefer :sql_injection
@@ -88,7 +88,7 @@ that if vulnerable, result in the responses for each injection being different.
 This is known as a blind SQL injection vulnerability.
 },
                 references:  {
-                    'OWASP'         => 'http://www.owasp.org/index.php/Blind_SQL_Injection',
+                    'OWASP'         => 'https://www.owasp.org/index.php/Blind_SQL_Injection',
                     'MITRE - CAPEC' => 'http://capec.mitre.org/data/definitions/7.html',
                     'WASC'          => 'http://projects.webappsec.org/w/page/13246963/SQL%20Injection',
                     'W3 Schools'    => 'http://www.w3schools.com/sql/sql_injection.asp'

--- a/components/checks/active/sql_injection_timing.rb
+++ b/components/checks/active/sql_injection_timing.rb
@@ -13,7 +13,7 @@
 #
 # @see http://cwe.mitre.org/data/definitions/89.html
 # @see http://capec.mitre.org/data/definitions/7.html
-# @see http://www.owasp.org/index.php/Blind_SQL_Injection
+# @see https://www.owasp.org/index.php/Blind_SQL_Injection
 class Arachni::Checks::SqlInjectionTiming < Arachni::Check::Base
 
     prefer :sql_injection, :sql_injection_differential
@@ -69,7 +69,7 @@ being sent by the server.
 This is known as a time-based blind SQL injection vulnerability.
 },
                 references:  {
-                    'OWASP'         => 'http://www.owasp.org/index.php/Blind_SQL_Injection',
+                    'OWASP'         => 'https://www.owasp.org/index.php/Blind_SQL_Injection',
                     'MITRE - CAPEC' => 'http://capec.mitre.org/data/definitions/7.html',
                     'WASC'          => 'http://projects.webappsec.org/w/page/13246963/SQL%20Injection',
                     'W3 Schools'    => 'http://www.w3schools.com/sql/sql_injection.asp'

--- a/components/checks/active/unvalidated_redirect.rb
+++ b/components/checks/active/unvalidated_redirect.rb
@@ -14,7 +14,7 @@
 # @author Tasos "Zapotek" Laskos <tasos.laskos@arachni-scanner.com>
 # @version 0.2.2
 #
-# @see http://www.owasp.org/index.php/Top_10_2010-A10-Unvalidated_Redirects_and_Forwards
+# @see https://www.owasp.org/index.php/Top_10_2010-A10-Unvalidated_Redirects_and_Forwards
 class Arachni::Checks::UnvalidatedRedirect < Arachni::Check::Base
 
     def self.payloads
@@ -89,7 +89,7 @@ Arachni has discovered that the server does not validate the parameter value pri
 to redirecting the client to the injected value.
 },
                 references:  {
-                    'OWASP Top 10 2010' => 'http://www.owasp.org/index.php/Top_10_2010-A10-Unvalidated_Redirects_and_Forwards'
+                    'OWASP Top 10 2010' => 'https://www.owasp.org/index.php/Top_10_2010-A10-Unvalidated_Redirects_and_Forwards'
                 },
                 tags:            %w(unvalidated redirect injection header location),
                 cwe:             819,

--- a/components/checks/active/unvalidated_redirect_dom.rb
+++ b/components/checks/active/unvalidated_redirect_dom.rb
@@ -11,7 +11,7 @@
 # @author Tasos "Zapotek" Laskos <tasos.laskos@arachni-scanner.com>
 # @version 0.1
 #
-# @see http://www.owasp.org/index.php/Top_10_2010-A10-Unvalidated_Redirects_and_Forwards
+# @see https://www.owasp.org/index.php/Top_10_2010-A10-Unvalidated_Redirects_and_Forwards
 class Arachni::Checks::UnvalidatedRedirectDOM < Arachni::Check::Base
 
     def self.payloads
@@ -77,7 +77,7 @@ Arachni has discovered that the web page does not validate the parameter value p
 to redirecting the client to the injected value.
 },
                 references:  {
-                    'OWASP Top 10 2010' => 'http://www.owasp.org/index.php/Top_10_2010-A10-Unvalidated_Redirects_and_Forwards'
+                    'OWASP Top 10 2010' => 'https://www.owasp.org/index.php/Top_10_2010-A10-Unvalidated_Redirects_and_Forwards'
                 },
                 tags:            %w(unvalidated redirect dom injection),
                 cwe:             819,

--- a/components/checks/active/xpath_injection.rb
+++ b/components/checks/active/xpath_injection.rb
@@ -12,8 +12,8 @@
 # @version 0.1.5
 #
 # @see http://cwe.mitre.org/data/definitions/91.html
-# @see http://www.owasp.org/index.php/XPATH_Injection
-# @see http://www.owasp.org/index.php/Testing_for_XPath_Injection_%28OWASP-DV-010%29
+# @see https://www.owasp.org/index.php/XPATH_Injection
+# @see https://www.owasp.org/index.php/Testing_for_XPath_Injection_%28OWASP-DV-010%29
 class Arachni::Checks::XpathInjection < Arachni::Check::Base
 
     def self.error_strings
@@ -63,7 +63,7 @@ Arachni injected special XPath query characters into the page and based on the
 responses from the server, has determined that the page is vulnerable to XPath injection.
 },
                 references:  {
-                    'OWASP' => 'http://www.owasp.org/index.php/XPATH_Injection',
+                    'OWASP' => 'https://www.owasp.org/index.php/XPATH_Injection',
                     'WASC' => 'http://projects.webappsec.org/w/page/13247005/XPath%20Injection'
                 },
                 tags:            %w(xpath database error injection regexp),

--- a/components/checks/active/xss.rb
+++ b/components/checks/active/xss.rb
@@ -122,7 +122,7 @@ HTML element content.
                     'ha.ckers' => 'http://ha.ckers.org/xss.html',
                     'Secunia'  => 'http://secunia.com/advisories/9716/',
                     'WASC' => 'http://projects.webappsec.org/w/page/13246920/Cross%20Site%20Scripting',
-                    'OWASP' => 'www.owasp.org/index.php/XSS_%28Cross_Site_Scripting%29_Prevention_Cheat_Sheet'
+                    'OWASP' => 'https://www.owasp.org/index.php/XSS_%28Cross_Site_Scripting%29_Prevention_Cheat_Sheet'
                 },
                 tags:            %w(xss regexp injection script),
                 cwe:             79,

--- a/components/checks/active/xss_event.rb
+++ b/components/checks/active/xss_event.rb
@@ -117,7 +117,7 @@ where `INJECTION_HERE` represents the location where the Arachni payload was det
                     'ha.ckers' => 'http://ha.ckers.org/xss.html',
                     'Secunia'  => 'http://secunia.com/advisories/9716/',
                     'WASC'     => 'http://projects.webappsec.org/w/page/13246920/Cross%20Site%20Scripting',
-                    'OWASP'    => 'www.owasp.org/index.php/XSS_%28Cross_Site_Scripting%29_Prevention_Cheat_Sheet'
+                    'OWASP'    => 'https://www.owasp.org/index.php/XSS_%28Cross_Site_Scripting%29_Prevention_Cheat_Sheet'
                 },
                 tags:            %w(xss event injection dom attribute),
                 cwe:             79,


### PR DESCRIPTION
Fixes an issue with relative links in the report found at e.g. http://downloads.arachni-scanner.com/dev/reports/report.html/#!/issues/trusted/severity/high/xss/1008740572 where the link to OWASP becomes http://downloads.arachni-scanner.com/dev/reports/report.html/www.owasp.org/index.php/XSS_%28Cross_Site_Scripting%29_Prevention_Cheat_Sheet.

Also changed all OWASP links that were not already using https to do this for consistency.