### PR TITLE
Fix user-supplied email addresses containing '+' character.

### DIFF
--- a/lib/arachni/element/form.rb
+++ b/lib/arachni/element/form.rb
@@ -426,11 +426,11 @@ class Form < Base
             DECODE_CACHE.fetch( string ) do
                 # Fast, but could throw error.
                 begin
-                    ::URI.decode_www_form_component string
+                    ::URI.decode_www_form_component string.gsub( '+', '%2B' )
 
                 # Slower, but reliable.
                 rescue ArgumentError
-                    URI.decode( string.gsub( '+', ' ' ) )
+                    URI.decode( string )
                 end
             end
         end


### PR DESCRIPTION
Autologin plugin fails if the user's email address (quite validly) contains a "+".

Using GMail labels of the form `my.user+label@gmail.com` I found a scenario where Arachni can't log into the app. On checking the server logs, I saw it was submitting email addresses of the form

`my.user label@gmail.com`

resulting in the server to return `422 Unprocessable Entity`

This is down to the way the form parameters are sanitised in https://github.com/Arachni/arachni/blob/master/lib/arachni/element/form.rb#L423

e.g.

```ruby
URI.decode_www_form_component "sean.handley+testing@gmail.com"
=> "sean.handley testing@gmail.com"
URI.decode_www_form_component "user[email]=sean.handley+testing@gmail.com"
=> "user[email]=sean.handley testing@gmail.com"
URI.decode "user[email]=sean.handley+testing@gmail.com"
=> "user[email]=sean.handley+testing@gmail.com"
URI.decode_www_form_component "user%5Bemail%5D=sean.handley%2Barachni%40datacentred.co.uk"
=> "user[email]=sean.handley+arachni@datacentred.co.uk"
URI.decode "user%5Bemail%5D=sean.handley%2Barachni%40datacentred.co.uk"
=> "user[email]=sean.handley+arachni@datacentred.co.uk"
```

An alternative approach is to instruct the user in the plugin documentation to enter the string in an encoded form at https://github.com/arachni/arachni/blob/master/components/plugins/autologin.rb#L110