### PR TITLE
Rate limiter plugin

### DIFF
--- a/components/plugins/rate_limiter.rb
+++ b/components/plugins/rate_limiter.rb
@@ -1,0 +1,76 @@
+=begin
+    Copyright 2010-2016 Tasos Laskos <tasos.laskos@arachni-scanner.com>
+
+    This file is part of the Arachni Framework project and is subject to
+    redistribution and commercial restrictions. Please see the Arachni Framework
+    web site for more information on licensing and terms of use.
+=end
+
+# Rate limiter for HTTP requests
+#
+# @author Bert Hekman <bert@pbwebmedia.com>
+class Arachni::Plugins::RateLimiter < Arachni::Plugin::Base
+    @@times_slept = 0
+    @@total_time_slept = 0.0
+
+    is_distributable
+
+    def prepare
+        http = framework.http
+
+        last_count = 0
+        last_response_time_sum = 0.0
+
+        http.on_queue do
+            last_count = 0
+            last_response_time_sum = 0.0
+        end
+
+        http.on_complete do
+            # Sleep once per burst.
+            next if http.burst_response_count == 0 || http.burst_response_count % http.max_concurrency != 0
+
+            burst_response_count = http.burst_response_count - last_count
+            burst_response_time = http.burst_response_time_sum - last_response_time_sum
+
+            last_count = http.burst_response_count
+            last_response_time_sum = http.burst_response_time_sum
+
+            sleep_time = (1.0 / options[:requests_per_second] * burst_response_count) - burst_response_time
+
+            next if sleep_time <= 0
+
+            print_info "Sleeping for #{sleep_time.round(3)} seconds"
+            sleep(sleep_time)
+
+            @@times_slept += 1
+            @@total_time_slept += sleep_time
+        end
+    end
+
+    def self.info
+        {
+            name:        'RateLimiter',
+            description: %q{
+Rate limits HTTP requests
+},
+            author:      'Bert Hekman <bert@pbwebmedia.com>',
+            tags:        %w(meta http rate limit),
+            version:     '0.1',
+            options: [
+                Options::Int.new('requests_per_second',
+                                 description: 'Requests per second.',
+                                 default: 20
+                )
+            ]
+        }
+    end
+
+    def self.times_slept
+        @@times_slept
+    end
+
+    def self.total_time_slept
+        @@total_time_slept
+    end
+end

--- a/spec/components/plugins/rate_limiter_spec.rb
+++ b/spec/components/plugins/rate_limiter_spec.rb
@@ -1,0 +1,53 @@
+require 'spec_helper'
+
+describe name_from_filename do
+    include_examples 'plugin'
+
+    def url
+        @url ||= web_server_url_for( name_from_filename ) + '/'
+    end
+
+    before :each do
+        options.plugins[component_name] = {
+            'requests_per_second' => 2
+        }
+
+        framework.plugins.load name_from_filename
+        framework.plugins.run
+    end
+
+    after :each do
+        framework.clean_up
+    end
+
+    context 'when the server response times' do
+        context 'are below threshold' do
+            it 'sleeps one time' do
+                http.max_concurrency = 1
+
+                time_start = Time.now
+
+                http.get(url)
+                http.run
+
+                run_time = Time.now - time_start
+
+                expect(framework.plugins[component_name].times_slept).to eq(1)
+                expect(framework.plugins[component_name].total_time_slept).to be <= 0.5
+                expect(run_time).to be > 0.5
+            end
+        end
+
+        context 'are above threshold' do
+            it 'does not sleep' do
+                http.max_concurrency = 1
+
+                http.get(url + 'slow')
+                http.run
+
+                expect(framework.plugins[component_name].times_slept).to eq(0)
+                expect(framework.plugins[component_name].total_time_slept).to eq(0.0)
+            end
+        end
+    end
+end

--- a/spec/support/servers/plugins/rate_limiter.rb
+++ b/spec/support/servers/plugins/rate_limiter.rb
@@ -1,0 +1,8 @@
+require 'sinatra'
+
+get '/' do
+end
+
+get '/slow' do
+    sleep 0.5
+end


### PR DESCRIPTION
To prevent arachni from spamming our webserver with request (which are heavy in our case), I've added a rate limiter plugin.

The requests per seconds can be configured and it will calculate how long it needs to sleep before continuing. For example if it is configured to 4 requests per second and a single burst did 8 requests in 0.2 seconds, it will sleep for ( (1.0 ÷ 4 × 8) − 0.2 = ) 1.8 seconds.

This is the first thing I've ever written in ruby and the first thing I've ever written for arachni, so please be gentle :)