### PR TITLE
Copy-paste error for element type definition of 'header' and 'parameter'

### DIFF
--- a/components/reporters/xml/schema.xsd
+++ b/components/reporters/xml/schema.xsd
@@ -714,7 +714,7 @@
 
     <xs:complexType name="headers">
         <xs:sequence>
-            <xs:element name="header" type="input"
+            <xs:element name="header" type="header"
                         minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
     </xs:complexType>
@@ -726,7 +726,7 @@
 
     <xs:complexType name="parameters">
         <xs:sequence>
-            <xs:element name="parameter" type="input"
+            <xs:element name="parameter" type="parameter"
                         minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
     </xs:complexType>


### PR DESCRIPTION
In your schema.xsd there are own types defined for the 'header' and 'parameter' elements. However, the defined types (itself named 'header' and 'parameter') are not used, instead the type 'input' is assigned.

This currently works without validation errors because all types 'input', 'header' and 'parameter' are identical in their definition. However, future changes (maybe in another pull request :-)) e.g. of type 'parameter' may lead to validation errors because the type is not used for the element.