### PR TITLE
Copy-paste error for element type definition of 'header' and 'parameter'

### DIFF
--- a/components/reporters/xml/schema.xsd
+++ b/components/reporters/xml/schema.xsd
@@ -715,7 +715,7 @@
 
     <xs:complexType name="headers">
         <xs:sequence>
-            <xs:element name="header" type="input"
+            <xs:element name="header" type="header"
                         minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
     </xs:complexType>
@@ -727,7 +727,7 @@
 
     <xs:complexType name="parameters">
         <xs:sequence>
-            <xs:element name="parameter" type="input"
+            <xs:element name="parameter" type="parameter"
                         minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
     </xs:complexType>


### PR DESCRIPTION
Pull request #753 now against `experimental`. Sorry for using `master` in #753.