### PR TITLE
Proposal: base64-encode data in XML reports.

### DIFF
--- a/components/reporters/xml.rb
+++ b/components/reporters/xml.rb
@@ -7,6 +7,7 @@
 =end
 
 require 'nokogiri'
+require 'base64'
 
 # Creates an XML report of the audit.
 #
@@ -190,6 +191,15 @@ class Arachni::Reporters::XML < Arachni::Reporter::Base
         s.to_s.gsub( "\0", NULL )
     end
 
+    def encode_if_null( v )
+        if v.include?("\0")
+            retval = [ true, Base64.strict_encode64(v) ]
+        else
+            retval = [ false, v ]
+        end
+        return retval
+    end
+
     def add_inputs( xml, inputs, name = :inputs )
         xml.send( name ) {
             inputs.each do |k, v|
@@ -209,7 +219,8 @@ class Arachni::Reporters::XML < Arachni::Reporter::Base
     def add_parameters( xml, parameters )
         xml.parameters {
             parameters.each do |k, v|
-                xml.parameter( name: replace_nulls( k ), value: replace_nulls( v ) )
+                needs_b64, v = encode_if_null( v )
+                xml.parameter( name: replace_nulls( k ), base64: needs_b64, value: v )
             end
         }
     end

--- a/components/reporters/xml/schema.xsd
+++ b/components/reporters/xml/schema.xsd
@@ -734,6 +734,7 @@
 
     <xs:complexType name="parameter">
         <xs:attribute name="name" type="xs:string"/>
+        <xs:attribute name="base64" type="xs:boolean"/>
         <xs:attribute name="value" type="xs:string"/>
     </xs:complexType>
 


### PR DESCRIPTION
As discussed in #753, here is my proposal for base64-encoding XML data. I had problems with NULL bytes in the `parameter` element so I chose this as example.

Advantage of this approach is that the data isn't modified (NULL byte replaced with placeholder), so you can be sure to get the full/original data also with XML. Drawback is that an additional attribute is used to identify base64-encoded attribute values or element content. And of course you have to consider base64-decoding during XML parsing.
