### PR TITLE
Replace watir-webdriver with watir

### DIFF
--- a/arachni.gemspec
+++ b/arachni.gemspec
@@ -105,7 +105,7 @@ Gem::Specification.new do |s|
     # Browser support for DOM/JS/AJAX analysis stuff.
     # Lock webdriver, newer versions has issues.
     s.add_dependency 'selenium-webdriver',  '3.0.1'
-    s.add_dependency 'watir-webdriver',     '0.8.0'
+    s.add_dependency 'watir',               '6.2.1'
 
     # Markdown to HTML conversion, used by the HTML report for component
     # descriptions.


### PR DESCRIPTION
Watir-webdriver has been moved and maintenance is now in the watir
gem. Update gemspec to reflect, fixes:

```
watir-webdriver/elements/table_cell.rb:6:in `alias_method':
undefined method `col_span' for class `Watir::TableCell'
(NameError)
```