### PR TITLE
Update ssl_interceptor.rb

### DIFF
--- a/lib/arachni/http/proxy_server/ssl_interceptor.rb
+++ b/lib/arachni/http/proxy_server/ssl_interceptor.rb
@@ -58,7 +58,7 @@ class SSLInterceptor < Connection
             cert            = OpenSSL::X509::Certificate.new
             cert.version    = 2
             cert.serial     = rand( 999999 )
-            cert.not_before = Time.new
+            cert.not_before = Time.new - 600
             cert.not_after  = cert.not_before + (60 * 60 * 24 * 365)
             cert.public_key = req.public_key
             cert.subject    = req.subject


### PR DESCRIPTION
ssl_interceptor is setting the certificate not valid before time to now, which was causing Firefox 59 to throw an error that the certificate was not yet valid. Adjusted the valid before time to be 10 minutes in the past.