### PR TITLE
Fingerprint the Adobe Experience Manager CMS framework

### DIFF
--- a/components/fingerprinters/frameworks/adobeaem.rb
+++ b/components/fingerprinters/frameworks/adobeaem.rb
@@ -1,0 +1,34 @@
+=begin
+=begin
+    Copyright 2010-2017 Sarosys LLC <http://www.sarosys.com>
+
+    This file is part of the Arachni Framework project and is subject to
+    redistribution and commercial restrictions. Please see the Arachni Framework
+    web site for more information on licensing and terms of use.
+=end
+
+module Arachni
+module Platform::Fingerprinters
+
+# Identifies Adobe AEM specific resources. 
+# Adobe AEM is a java and OSGi based CMS framework commonly used among big enterprises.
+# AEM can be fingerprinted by very specific paths starting with /etc/designs or granite.
+# Old AEM versions also expose the term Day Servlet engine in the server header
+#
+# @author Thomas Hartmann <thomysec@gmx.org>
+# @version 0.1
+class AdobeAem < Platform::Fingerprinter
+
+    def run
+        if uri.path =~ /.etc\/designs\d*\/*/ || 
+            uri.path =~ /.granite\d*\/*/ ||
+            server_or_powered_by_include?( 'Day' )
+
+             platforms << :java << :adobeaem
+        end
+    end
+
+end
+
+end
+end

--- a/components/fingerprinters/frameworks/adobeaem.rb
+++ b/components/fingerprinters/frameworks/adobeaem.rb
@@ -12,8 +12,8 @@ module Platform::Fingerprinters
 
 # Identifies Adobe AEM specific resources. 
 # Adobe AEM is a java and OSGi based CMS framework commonly used among big enterprises.
-# AEM can be fingerprinted by very specific paths starting with /etc/designs or granite.
-# Old AEM versions also expose the term Day Servlet engine in the server header
+# AEM can be fingerprinted by very specific paths starting with /etc/designs, etc.clientlibs, _jcr_content or containing the granite element in it's path.
+# Old AEM versions also expose the name Day-Servlet-Engine in the server header
 #
 # @author Thomas Hartmann <thomysec@gmx.org>
 # @version 0.1
@@ -21,8 +21,10 @@ class AdobeAem < Platform::Fingerprinter
 
     def run
         if uri.path =~ /.etc\/designs\d*\/*/ || 
+            uri.path =~ /.etc\.clientlib\d*\/*/ ||
+            uri.path =~ /.jcr_content\d*\/*/ ||
             uri.path =~ /.granite\d*\/*/ ||
-            server_or_powered_by_include?( 'Day' )
+            server_or_powered_by_include?( 'Day-Servlet-Engine' )
 
              platforms << :java << :adobeaem
         end

--- a/lib/arachni/platform/manager.rb
+++ b/lib/arachni/platform/manager.rb
@@ -113,7 +113,8 @@ class Manager
         :django,
         :aspx_mvc,
         :jsf,
-        :cherrypy
+        :cherrypy,
+        :adobeaem
     ]
 
     PLATFORM_NAMES = {
@@ -172,7 +173,8 @@ class Manager
         rails:    'Ruby on Rails',
         aspx_mvc: 'ASP.NET MVC',
         jsf:      'JavaServer Faces',
-        cherrypy: 'CherryPy'
+        cherrypy: 'CherryPy',
+        adobeaem: 'Adobe AEM'
     }
 
     PLATFORM_CACHE_SIZE = 500

--- a/spec/components/fingerprinters/frameworks/adobeaem_spec.rb
+++ b/spec/components/fingerprinters/frameworks/adobeaem_spec.rb
@@ -7,7 +7,7 @@ describe Arachni::Platform::Fingerprinters::AdobeAem do
         [:java]
     end
 
-    context 'when the page has a /etc/design directory in a path' do
+    context 'when the page has a /etc/design segment in a path' do
         it 'identifies it as Adobe AEM' do
             check_platforms Arachni::Page.from_data( url: 'http://stuff.com/etc/designs/we-retail/components/mainnav/menunav/publish.0.20180724073205.min.js' )
         end
@@ -16,6 +16,18 @@ describe Arachni::Platform::Fingerprinters::AdobeAem do
     context 'when the page has a granite token in the path' do
         it 'identifies it as Adobe AEM' do
             check_platforms Arachni::Page.from_data( url: 'http://stuff.com/libs/granite/csrf/token.json' )
+        end
+    end
+
+    context 'when the page has a _jcr_content element in the path' do
+        it 'identifies it as Adobe AEM' do
+            check_platforms Arachni::Page.from_data( url: 'http://stuff.com/content/we-retail/us/en/_jcr_content/root/responsivegrid/category_teaser_465639357.thumb.png' )
+        end
+    end
+
+    context 'when the page has a /etc.clientlibs element in the path' do
+        it 'identifies it as Adobe AEM' do
+            check_platforms Arachni::Page.from_data( url: 'http://stuff.com/etc.clientlibs/we-retail/components/chat.0.20180724073205.min.css' )
         end
     end
 

--- a/spec/components/fingerprinters/frameworks/adobeaem_spec.rb
+++ b/spec/components/fingerprinters/frameworks/adobeaem_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+describe Arachni::Platform::Fingerprinters::AdobeAem do
+    include_examples 'fingerprinter'
+
+    def platforms
+        [:java]
+    end
+
+    context 'when the page has a /etc/design directory in a path' do
+        it 'identifies it as Adobe AEM' do
+            check_platforms Arachni::Page.from_data( url: 'http://stuff.com/etc/designs/we-retail/components/mainnav/menunav/publish.0.20180724073205.min.js' )
+        end
+    end
+
+    context 'when the page has a granite token in the path' do
+        it 'identifies it as Adobe AEM' do
+            check_platforms Arachni::Page.from_data( url: 'http://stuff.com/libs/granite/csrf/token.json' )
+        end
+    end
+
+    context 'when there is a Day-Servlet-Engine header' do
+        it 'identifies it as Adobe AEM' do
+            check_platforms Arachni::Page.from_data(
+                url:     'http://stuff.com/blah',
+                response: { headers: { 'Server' => 'Day-Servlet-Engine/4.1.24'  } }
+            )
+        end
+    end
+
+end


### PR DESCRIPTION
This pull requests adds a fingerprinter to identify the Adobe Experience Manager (AEM) which is a java and OSGi based content management framework and platform.
AEM driven web sites can be identified by very specific paths referenced from within the HTML source or includes scripts e.g. 
- /etc/design as a primary location of CSS and JS resources 
- The term granite e.g. in the path /libs/granite/token.json which stands for an Adobe internal UI framework
- /etc.clientlibs which is the a proxy erefrencing so called CSS and JS clientlibraries
- jcr_content which maps to a subnode of the current page inside AEM's cotent repository

AEM is pretty common among fortune 500 companies and can be pretty challenging to secure if not done right.

